### PR TITLE
지도 마커 변환 로직 변경

### DIFF
--- a/src/main/java/logX/TTT/location/LocationController.java
+++ b/src/main/java/logX/TTT/location/LocationController.java
@@ -1,0 +1,29 @@
+package logX.TTT.location;
+
+import logX.TTT.location.model.MarkerWithPostsDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/locations")
+public class LocationController {
+    @Autowired
+    private LocationService locationService;
+
+    @GetMapping("/posts")
+    public ResponseEntity<List<MarkerWithPostsDTO>> getMarkerWithPostsByLocationRange (
+            @RequestParam double northEastLat,
+            @RequestParam double northEastLon,
+            @RequestParam double southWestLat,
+            @RequestParam double southWestLon
+    ) {
+        List<MarkerWithPostsDTO> markers = locationService.getMarkersWithPostsByLocationRange(northEastLat, northEastLon, southWestLat, southWestLon);
+        return ResponseEntity.ok(markers);
+    }
+}

--- a/src/main/java/logX/TTT/location/LocationRepository.java
+++ b/src/main/java/logX/TTT/location/LocationRepository.java
@@ -1,10 +1,22 @@
 package logX.TTT.location;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
+    @Query("SELECT l FROM Location l " +
+            "WHERE l.latitude BETWEEN :southWestLat AND :northEastLat " +
+            "AND l.longitude BETWEEN :southWestLng AND :northEastLng")
+    List<Location> findByLocationRange(
+            @Param("southWestLat") double southWestLat,
+            @Param("southWestLng") double southWestLng,
+            @Param("northEastLat") double northEastLat,
+            @Param("northEastLng") double northEastLng
+    );
+
     // 글에 첨부된 장소 리스트 반환
     List<Location> findByPostId(Long postId);
 

--- a/src/main/java/logX/TTT/location/LocationService.java
+++ b/src/main/java/logX/TTT/location/LocationService.java
@@ -1,0 +1,42 @@
+package logX.TTT.location;
+
+import logX.TTT.location.model.MarkerWithPostsDTO;
+import logX.TTT.post.model.PostSummaryDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LocationService {
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    public List<MarkerWithPostsDTO> getMarkersWithPostsByLocationRange(double southWestLat, double southWestLng, double northEastLat, double northEastLng) {
+        List<Location> locations = locationRepository.findByLocationRange(southWestLat, southWestLng, northEastLat, northEastLng);
+
+        return locations.stream()
+                .collect(Collectors.groupingBy(
+                        location -> new MarkerWithPostsDTO(location.getName(), location.getLatitude(), location.getLongitude(), null),
+                        Collectors.mapping(Location::getPost, Collectors.toList())
+                ))
+                .entrySet().stream()
+                .map(entry -> {
+                    MarkerWithPostsDTO markerDTO = entry.getKey();
+                    List<PostSummaryDTO> postSummaries = entry.getValue().stream()
+                            .map(post -> new PostSummaryDTO(
+                                    post.getId(),
+                                    post.getTitle(),
+                                    20,// Entity 미완성 - 추후 교체: post.getLikeCount(),
+                                    40,// Entity 미완성 - 추후 교체: post.getViewCount(),
+                                    "image/image.jpg"// Entity 미완성 - 추후 교체: post.getImageUrl()
+                            ))
+                            .collect(Collectors.toList());
+                    markerDTO.setPosts(postSummaries);
+                    return markerDTO;
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/logX/TTT/location/model/MarkerWithPostsDTO.java
+++ b/src/main/java/logX/TTT/location/model/MarkerWithPostsDTO.java
@@ -1,0 +1,15 @@
+package logX.TTT.location.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MarkerWithPostsDTO {
+    private String name;
+    private double latitude;
+    private double longitude;
+
+}

--- a/src/main/java/logX/TTT/location/model/MarkerWithPostsDTO.java
+++ b/src/main/java/logX/TTT/location/model/MarkerWithPostsDTO.java
@@ -1,8 +1,11 @@
 package logX.TTT.location.model;
 
+import logX.TTT.post.model.PostSummaryDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -11,5 +14,5 @@ public class MarkerWithPostsDTO {
     private String name;
     private double latitude;
     private double longitude;
-
+    private List<PostSummaryDTO> posts;
 }

--- a/src/main/java/logX/TTT/post/PostRepository.java
+++ b/src/main/java/logX/TTT/post/PostRepository.java
@@ -10,16 +10,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 특정 회원이 작성한 모든 게시글 반환 메소드
     List<Post> findByMemberId(Long memberId);
 
-    // 주어진 위치 사이의 글 목록 반환하는 메소드
-    @Query("SELECT DISTINCT p FROM Post p JOIN p.locations l " +
-            "WHERE l.latitude BETWEEN :minLatitude AND :maxLatitude " +
-            "AND l.longitude BETWEEN :minLongitude AND :maxLongitude")
-    List<Post> findByLocationRange(
-            @Param("minLatitude") double minLatitude,
-            @Param("minLongitude") double minLongitude,
-            @Param("maxLatitude") double maxLatitude,
-            @Param("maxLongitude") double maxLongitude
-    );
 
     List<Post> findByUsername(String username);
     List<Post> findByTitleContainingOrContentContaining(String keyword);

--- a/src/main/java/logX/TTT/post/model/PostSummaryDTO.java
+++ b/src/main/java/logX/TTT/post/model/PostSummaryDTO.java
@@ -1,0 +1,16 @@
+package logX.TTT.post.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSummaryDTO {
+    private Long postId;
+    private String title;
+    private int likeCount;
+    private int viewCount;
+    private String imageUrl;
+}


### PR DESCRIPTION
### 로직 변경
- 기존
  - 상하좌우 좌표 4개를 받아서 계산
- 변경
  - 북동, 남서 좌표 2개를 받아서 계산
---
### DTO 추가
- MarkerWithPostsDTO
  - 장소이름
  - 위도, 경도
  - 글 목록 [ {postId} ]
- PostSummaryDTO
  - 글 제목
  - 세부 글 id {postId}
  - 대표 이미지 (Post Entity 미완성 - 더미데이터로 구현)
  - 좋아요 수 (Post Entity 미완성 - 더미데이터로 구현)
  - 조회수 (Post Entity 미완성 - 더미데이터로 구현)
---
### Refactor
- 좌표 계산 비즈니스 로직
  - PostRepository -> LocationRepository
 