### PR TITLE
자기소개 추가 & 최근 검색 기록 제공

### DIFF
--- a/sql.sql
+++ b/sql.sql
@@ -4,6 +4,7 @@ CREATE TABLE member
     username          VARCHAR(255) NOT NULL,
     email             VARCHAR(255) NOT NULL,
     password          VARCHAR(255) NOT NULL,
+    introduction      VARCHAR(255) DEFAULT '한 줄 소개입니다. 자신을 멋있게 소개해보세요!',
     created_at        DATE         NOT NULL,
     profile_image_url VARCHAR(255),
     total_likes       INT DEFAULT 0,

--- a/src/main/java/logX/TTT/member/Member.java
+++ b/src/main/java/logX/TTT/member/Member.java
@@ -30,6 +30,9 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    @Column
+    private String introduction;
+
     @Column(name = "created_at", nullable = false)
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/src/main/java/logX/TTT/member/MemberService.java
+++ b/src/main/java/logX/TTT/member/MemberService.java
@@ -50,6 +50,7 @@ public class MemberService {
         return new UserInfoDTO(
                 member.getEmail(),
                 member.getUsername(),
+                member.getIntroduction(),
                 member.getProfileImageUrl(),
                 member.getCreatedAt()
         );
@@ -65,6 +66,7 @@ public class MemberService {
                 .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
 
         member.setUsername(updateMemberDTO.getUsername());
+        member.setIntroduction(updateMemberDTO.getIntroduction());
         member.setProfileImageUrl(updateMemberDTO.getProfileImageUrl());
 
         return memberRepository.save(member);
@@ -90,6 +92,7 @@ public class MemberService {
         return new UserInfoDTO(
                 member.getEmail(),
                 member.getUsername(),
+                member.getIntroduction(),
                 member.getProfileImageUrl(),
                 member.getCreatedAt()
         );

--- a/src/main/java/logX/TTT/member/model/UpdateMemberDTO.java
+++ b/src/main/java/logX/TTT/member/model/UpdateMemberDTO.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class UpdateMemberDTO {
     private String username;
     private String profileImageUrl;
+    private String introduction;
 }

--- a/src/main/java/logX/TTT/member/model/UserInfoDTO.java
+++ b/src/main/java/logX/TTT/member/model/UserInfoDTO.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 public class UserInfoDTO {
     private String email;
     private String username;
+    private String introduction;
     private String profileImageUrl;
     private LocalDateTime created_at;
 }

--- a/src/main/java/logX/TTT/search/Search.java
+++ b/src/main/java/logX/TTT/search/Search.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import logX.TTT.member.Member;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -22,4 +24,7 @@ public class Search {
 
     @Column(name = "query", nullable = false)
     private String query;
+
+    @Column(name = "searched_at", nullable = false)
+    private LocalDateTime searchedAt;
 }

--- a/src/main/java/logX/TTT/search/Search.java
+++ b/src/main/java/logX/TTT/search/Search.java
@@ -11,14 +11,14 @@ import lombok.*;
 @Builder
 @Entity
 @Table(name = "search_history")
-public class SearchHistory {
+public class Search {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
-    private Long memberId;
+    private Member member;
 
     @Column(name = "query", nullable = false)
     private String query;

--- a/src/main/java/logX/TTT/search/SearchController.java
+++ b/src/main/java/logX/TTT/search/SearchController.java
@@ -4,11 +4,9 @@ import logX.TTT.member.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -26,4 +24,12 @@ public class SearchController {
         searchService.saveSearchQuery(memberId, query);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/{username}")
+    public ResponseEntity<List<String>> getRecentSearchQueries(@PathVariable String username) {
+        Long memberId = memberService.getMemberIdByUsername(username);
+        List<String> recentQueries = searchService.getRecentSearchQueries(memberId);
+        return ResponseEntity.ok(recentQueries);
+    }
+
 }

--- a/src/main/java/logX/TTT/search/SearchHistoryRepository.java
+++ b/src/main/java/logX/TTT/search/SearchHistoryRepository.java
@@ -1,8 +1,0 @@
-package logX.TTT.search;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
-
-public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
-    List<SearchHistory> findTop10ByMemberIdOrderBySearchedAtDesc(Long memberId);
-}

--- a/src/main/java/logX/TTT/search/SearchRepository.java
+++ b/src/main/java/logX/TTT/search/SearchRepository.java
@@ -1,0 +1,8 @@
+package logX.TTT.search;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface SearchRepository extends JpaRepository<Search, Long> {
+    List<Search> findTop10ByMemberIdOrderBySearchedAtDesc(Long memberId);
+}

--- a/src/main/java/logX/TTT/search/SearchService.java
+++ b/src/main/java/logX/TTT/search/SearchService.java
@@ -1,5 +1,7 @@
 package logX.TTT.search;
 
+import logX.TTT.member.Member;
+import logX.TTT.member.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -9,24 +11,29 @@ import java.util.stream.Collectors;
 @Service
 public class SearchService {
     @Autowired
-    private SearchHistoryRepository searchHistoryRepository;
+    private SearchRepository searchHistoryRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     public void saveSearchQuery(Long memberId, String query) {
-        SearchHistory searchHistory = new SearchHistory();
-        searchHistory.setMemberId(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+
+        Search searchHistory = new Search();
+        searchHistory.setMember(member);
         searchHistory.setQuery(query);
         searchHistoryRepository.save(searchHistory);
 
-        List<SearchHistory> searchHistoryList = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
-        if(searchHistoryList.size() > 10) {
+        List<Search> searchHistoryList = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
+        if (searchHistoryList.size() > 10) {
             searchHistoryRepository.delete(searchHistoryList.get(searchHistoryList.size() - 1));
         }
     }
 
     public List<String> getRecentSearchQueries(Long memberId) {
-        List<SearchHistory> searchHistories = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
+        List<Search> searchHistories = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
         return searchHistories.stream()
-                .map(SearchHistory::getQuery)
+                .map(Search::getQuery)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### 자기소개
- 기본적으로 `한 줄 소개입니다. 자신을 멋있게 소개해보세요!` 설정 (SQL 수정)
- 프로필 수정 탭에서 수정 가능
- VARCHAR(255)로 한글 125자 내외 저장 가능 (FE에서 요구사항에 맞춰 70자로 제한)

### 최근 검색 기록
- 기존 사용하던 Search 테이블을 활용하여 현재까지 저장된 query(String)들을 List로 반환

### Rename
- SearchHistory -> Search로 이름 통일