### PR TITLE
게시물 다중 삭제 기능 추가

### DIFF
--- a/src/main/java/logX/TTT/post/PostController.java
+++ b/src/main/java/logX/TTT/post/PostController.java
@@ -46,10 +46,24 @@ public class PostController {
         }
     }
 
+    // 하나의 게시물 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(@PathVariable Long id) {
         try {
             postService.deletePost(id);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
+    // 여러 개의 게시물 삭제
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteMultiplePosts(@RequestBody List<Long> ids) {
+        try {
+            for (Long id : ids) {
+                postService.deletePost(id);
+            }
             return ResponseEntity.noContent().build();
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();


### PR DESCRIPTION
1. 게시물 다중 삭제 기능 추가
 - 기존의 코드와 같은 URL 경로를 통해 삭제 (/posts/{ids}) 로 구현하게 되면 URL이 너무 길어질 수 있어 문제 발생 가능.
   또한 가독성이 떨어질 수 있다고 판단하여 여러개의 게시물 ID를 JSON 형태로 전달하도록 작성
 - 기존의 코드와 형태는 다르지만 겹치지 않아 문제 오류 발생하지 않음