### PR TITLE
Scrap 기능 및 SQL문 추가

### DIFF
--- a/sql.sql
+++ b/sql.sql
@@ -85,4 +85,14 @@ CREATE TABLE search_history
     FOREIGN KEY (member_id) REFERENCES member (id)
 );
 
+CREATE TABLE scrap
+(
+    id         INT AUTO_INCREMENT PRIMARY KEY,
+    member_id  INT NOT NULL,
+    post_id    INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (member_id) REFERENCES member (id),
+    FOREIGN KEY (post_id) REFERENCES post (id),
+    UNIQUE (member_id, post_id) -- 사용자가 같은 게시글을 여러 번 스크랩할 수 없도록
+);
 

--- a/src/main/java/logX/TTT/scrap/Scrap.java
+++ b/src/main/java/logX/TTT/scrap/Scrap.java
@@ -1,0 +1,27 @@
+package logX.TTT.scrap;
+
+import jakarta.persistence.*;
+import logX.TTT.member.Member;
+import logX.TTT.post.Post;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "scrap")
+public class Scrap {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/src/main/java/logX/TTT/scrap/ScrapController.java
+++ b/src/main/java/logX/TTT/scrap/ScrapController.java
@@ -1,0 +1,30 @@
+package logX.TTT.scrap;
+
+import logX.TTT.scrap.model.ScrapDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/scraps")
+public class ScrapController {
+    @Autowired
+    private ScrapService scrapService;
+
+    // 게시글 스크랩 요청
+    @PostMapping
+    public ResponseEntity<Void> scrapPost(@RequestBody ScrapDTO scrapDTO) {
+        scrapService.scrapPost(scrapDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    // 특정 사용자의 스크랩 목록 조회
+    @GetMapping("/{memberId}")
+    public ResponseEntity<List<ScrapDTO>> getScraps(@PathVariable Long memberId) {
+        List<ScrapDTO> scraps = scrapService.getScraps(memberId);
+        return ResponseEntity.ok(scraps);
+    }
+}

--- a/src/main/java/logX/TTT/scrap/ScrapRepository.java
+++ b/src/main/java/logX/TTT/scrap/ScrapRepository.java
@@ -1,0 +1,13 @@
+package logX.TTT.scrap;
+
+import logX.TTT.member.Member;
+import logX.TTT.post.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+    List<Scrap> findByMember(Member member);
+    List<Scrap> findByPost(Post post);
+    void deleteByMemberAndPost(Member member, Post post); // 특정 member와 post의 조합으로 삭제
+}

--- a/src/main/java/logX/TTT/scrap/ScrapService.java
+++ b/src/main/java/logX/TTT/scrap/ScrapService.java
@@ -1,0 +1,50 @@
+package logX.TTT.scrap;
+
+import logX.TTT.member.Member;
+import logX.TTT.member.MemberRepository;
+import logX.TTT.post.Post;
+import logX.TTT.post.PostRepository;
+import logX.TTT.scrap.model.ScrapDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ScrapService {
+    @Autowired
+    private ScrapRepository scrapRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    //수정 할 예정
+    public ScrapService(ScrapRepository scrapRepository, PostRepository postRepository, MemberRepository memberRepository) {
+        this.scrapRepository = scrapRepository;
+        this.postRepository = postRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    public void scrapPost(ScrapDTO scrapDTO) {
+        Member member = memberRepository.findById(scrapDTO.getMemberId()).orElseThrow(() -> new RuntimeException("Member not found"));
+        Post post = postRepository.findById(scrapDTO.getPostId()).orElseThrow(() -> new RuntimeException("Post not found"));
+
+        Scrap scrap = new Scrap();
+        scrap.setMember(member);
+        scrap.setPost(post);
+        scrapRepository.save(scrap);
+    }
+
+    public List<ScrapDTO> getScraps(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not found"));
+        List<Scrap> scraps = scrapRepository.findByMember(member);
+
+        return scraps.stream()
+                .map(scrap -> new ScrapDTO(scrap.getId(), scrap.getMember().getId(), scrap.getPost().getId()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/logX/TTT/scrap/model/ScrapDTO.java
+++ b/src/main/java/logX/TTT/scrap/model/ScrapDTO.java
@@ -1,0 +1,16 @@
+package logX.TTT.scrap.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScrapDTO {
+    private Long id;
+    private Long memberId;
+    private Long postId;
+}


### PR DESCRIPTION
1. Scrap 테이블 추가
 -구조
   id: 고유 ID
   member_id: 스크랩한 사용자의 ID (외래 키)
   post_id: 스크랩된 게시글의 ID (외래 키)
   created_at: 스크랩 생성 시간 (기본값: 현재 시간)
   제약 조건: member_id와 post_id의 조합에 대한 유니크 제약 조건 추가(한 사용자가 같은 게시물을 중복 스크랩할 수 없도록)

2. ScrapController 구현
 스크랩 추가, 조회, 삭제 기능을 처리하는 클래스
클라이언트의 요청을 처리하고, 스크랩 기능을 서비스 레이어에 전달

3. ScrapService 구현
 비즈니스 로직을 처리하는 클래스(스크랩 추가, 스크랩 목록 조회 및 스크랩 삭제 기능)

4. SQL 스키마
sql.sql 파일에 새로운 scrap 테이블 생성 쿼리를 추가