### PR TITLE
Post DTO 관련 & 작은 오류 수정

### DIFF
--- a/sql.sql
+++ b/sql.sql
@@ -5,10 +5,10 @@ CREATE TABLE member
     email             VARCHAR(255) NOT NULL,
     password          VARCHAR(255) NOT NULL,
     introduction      VARCHAR(255) DEFAULT '한 줄 소개입니다. 자신을 멋있게 소개해보세요!',
-    created_at        DATE         NOT NULL,
+    created_at        TIMESTAMP    NOT NULL,
     profile_image_url VARCHAR(255),
-    total_likes       INT DEFAULT 0,
-    total_views       INT DEFAULT 0
+    total_likes       INT          DEFAULT 0,
+    total_views       INT          DEFAULT 0
 );
 
 

--- a/sql.sql
+++ b/sql.sql
@@ -77,9 +77,10 @@ CREATE TABLE views
 
 CREATE TABLE search_history
 (
-    id        INT AUTO_INCREMENT PRIMARY KEY,
-    member_id INT          NOT NULL,
-    query     VARCHAR(255) NOT NULL,
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    member_id   INT          NOT NULL,
+    query       VARCHAR(255) NOT NULL,
+    searched_at TIMESTAMP    NOT NULL,
     FOREIGN KEY (member_id) REFERENCES member (id)
 );
 

--- a/src/main/java/logX/TTT/interest/InterestController.java
+++ b/src/main/java/logX/TTT/interest/InterestController.java
@@ -1,6 +1,7 @@
 package logX.TTT.interest;
 
 import logX.TTT.post.Post;
+import logX.TTT.post.model.PostResponseDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -17,8 +18,8 @@ public class InterestController {
     private InterestService interestService;
 
     @GetMapping("/{username}")
-    public ResponseEntity<List<Post>> getRecommendedPosts(@PathVariable String username) {
-        List<Post> recommendedPosts = interestService.getRecommendedPosts(username);
+    public ResponseEntity<List<PostResponseDTO>> getRecommendedPosts(@PathVariable String username) {
+        List<PostResponseDTO> recommendedPosts = interestService.getRecommendedPosts(username);
         return ResponseEntity.ok(recommendedPosts);
     }
 }

--- a/src/main/java/logX/TTT/interest/InterestService.java
+++ b/src/main/java/logX/TTT/interest/InterestService.java
@@ -32,7 +32,7 @@ public class InterestService {
         List<String> recentQueries = searchService.getRecentSearchQueries(memberId);
         List<Post> recommendedPosts = new ArrayList<>();
         for (String query : recentQueries) {
-            recommendedPosts.addAll(postRepository.findByTitleContainingOrContentContaining(query));
+            recommendedPosts.addAll(postRepository.findByTitleContainingOrContentDataContaining(query));
         }
         return postService.convertToResponseDTOs(recommendedPosts);
     }

--- a/src/main/java/logX/TTT/interest/InterestService.java
+++ b/src/main/java/logX/TTT/interest/InterestService.java
@@ -3,6 +3,8 @@ package logX.TTT.interest;
 import logX.TTT.member.MemberService;
 import logX.TTT.post.Post;
 import logX.TTT.post.PostRepository;
+import logX.TTT.post.PostService;
+import logX.TTT.post.model.PostResponseDTO;
 import logX.TTT.search.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,6 +16,9 @@ import java.util.List;
 public class InterestService {
 
     @Autowired
+    private PostService postService;
+
+    @Autowired
     private PostRepository postRepository;
 
     @Autowired
@@ -22,13 +27,13 @@ public class InterestService {
     @Autowired
     private MemberService memberService;
 
-    public List<Post> getRecommendedPosts(String username) {
+    public List<PostResponseDTO> getRecommendedPosts(String username) {
         Long memberId = memberService.getMemberIdByUsername(username);
         List<String> recentQueries = searchService.getRecentSearchQueries(memberId);
         List<Post> recommendedPosts = new ArrayList<>();
         for (String query : recentQueries) {
             recommendedPosts.addAll(postRepository.findByTitleContainingOrContentContaining(query));
         }
-        return recommendedPosts;
+        return postService.convertToResponseDTOs(recommendedPosts);
     }
 }

--- a/src/main/java/logX/TTT/member/MemberService.java
+++ b/src/main/java/logX/TTT/member/MemberService.java
@@ -30,14 +30,19 @@ public class MemberService {
 
 
     public Member signup(SignupDTO form) {
-        if(memberRepository.existsByEmail(form.getEmail())) {
+        if (memberRepository.existsByEmail(form.getEmail())) {
             throw new RuntimeException("해당 이메일로 가입된 회원이 있습니다.");
         }
+
         Member member = new Member();
         member.setUsername(form.getUsername());
         member.setEmail(form.getEmail());
         member.setPassword(passwordEncoder.encode(form.getPassword()));
         member.setProfileImageUrl(form.getProfileImageUrl());
+        member.setIntroduction("한 줄 소개입니다. 자신을 멋있게 소개해보세요!");
+        member.setTotalLikes(0);
+        member.setTotalViews(0);
+
         return memberRepository.save(member);
     }
 

--- a/src/main/java/logX/TTT/post/PostRepository.java
+++ b/src/main/java/logX/TTT/post/PostRepository.java
@@ -11,9 +11,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 특정 회원이 작성한 모든 게시글 반환 메소드
     List<Post> findByMemberId(Long memberId);
 
-
+    @Query("SELECT p FROM Post p WHERE p.member.username = :username")
     List<Post> findByUsername(String username);
-    List<Post> findByTitleContainingOrContentContaining(String keyword);
+
+
+    @Query("SELECT DISTINCT p FROM Post p LEFT JOIN p.contentList c " +
+            "WHERE p.title LIKE %:keyword% OR c.data LIKE %:query%")
+    List<Post> findByTitleContainingOrContentDataContaining(@Param("query") String keyword);
 
     List<Post> findByMember(Member member);
 }

--- a/src/main/java/logX/TTT/post/PostService.java
+++ b/src/main/java/logX/TTT/post/PostService.java
@@ -86,6 +86,12 @@ public class PostService {
         );
     }
 
+    public List<PostResponseDTO> convertToResponseDTOs(List<Post> posts) {
+        return posts.stream()
+                .map(this::convertToResponseDTO)
+                .collect(Collectors.toList());
+    }
+
     public List<PostResponseDTO> getPostsByUsername(String username) {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));

--- a/src/main/java/logX/TTT/search/Search.java
+++ b/src/main/java/logX/TTT/search/Search.java
@@ -3,6 +3,7 @@ package logX.TTT.search;
 import jakarta.persistence.*;
 import logX.TTT.member.Member;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -26,5 +27,6 @@ public class Search {
     private String query;
 
     @Column(name = "searched_at", nullable = false)
+    @CreationTimestamp
     private LocalDateTime searchedAt;
 }


### PR DESCRIPTION
### PostResponseDTO
수정사항 반영 #22 : 관심사 글 찾기 => 글 반환 시
- 기존
  - PostDTO
- 변경
  - PostResponseDTO
---
### Bugs
- PostRepository의 `findByUsername` 메소드가 작동하지 않는 오류
  - `member.username`이 필요하기 때문에, 직접 `@Query`를 달아 SQL문 작성하여 해결
- 회원가입 시 한줄소개, 총 좋아요 수, 총 조회수 수가 없어서 생기는 오류
  - MemberService에 각각의 초기값을 추어 해결
- SQL 수정
  - Member 테이블의 created_at 칼럼의 데이터 타입을 `TIMESTAMP`로 통일
  - Search 테이블의 searched_at 칼럼에 `@CreationLocalStamp`를 설정하여 자동으로 시간 설정 기능 추가