### PR TITLE
검색기록 삭제기능 구현

### DIFF
--- a/src/main/java/logX/TTT/interest/InterestService.java
+++ b/src/main/java/logX/TTT/interest/InterestService.java
@@ -6,6 +6,7 @@ import logX.TTT.post.PostRepository;
 import logX.TTT.post.PostService;
 import logX.TTT.post.model.PostResponseDTO;
 import logX.TTT.search.SearchService;
+import logX.TTT.search.model.SearchDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,10 +30,10 @@ public class InterestService {
 
     public List<PostResponseDTO> getRecommendedPosts(String username) {
         Long memberId = memberService.getMemberIdByUsername(username);
-        List<String> recentQueries = searchService.getRecentSearchQueries(memberId);
+        List<SearchDTO> recentQueries = searchService.getRecentSearchQueries(memberId);
         List<Post> recommendedPosts = new ArrayList<>();
-        for (String query : recentQueries) {
-            recommendedPosts.addAll(postRepository.findByTitleContainingOrContentDataContaining(query));
+        for (SearchDTO searchDTO : recentQueries) {
+            recommendedPosts.addAll(postRepository.findByTitleContainingOrContentDataContaining(searchDTO.getQuery()));
         }
         return postService.convertToResponseDTOs(recommendedPosts);
     }

--- a/src/main/java/logX/TTT/search/Search.java
+++ b/src/main/java/logX/TTT/search/Search.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public class Search {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long searchedHistoryId;
+    private Long searchHistoryId;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/logX/TTT/search/Search.java
+++ b/src/main/java/logX/TTT/search/Search.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public class Search {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long searchedHistoryId;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/logX/TTT/search/SearchController.java
+++ b/src/main/java/logX/TTT/search/SearchController.java
@@ -33,4 +33,11 @@ public class SearchController {
         return ResponseEntity.ok(recentQueries);
     }
 
+    @DeleteMapping("/{username}/{id}")
+    public ResponseEntity<Void> deleteQuery(@PathVariable String username, @PathVariable Long id) {
+        Long memberId = memberService.getMemberIdByUsername(username);
+        searchService.deleteQuery(memberId, id);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/logX/TTT/search/SearchController.java
+++ b/src/main/java/logX/TTT/search/SearchController.java
@@ -33,10 +33,10 @@ public class SearchController {
         return ResponseEntity.ok(recentQueries);
     }
 
-    @DeleteMapping("/{username}/{id}")
-    public ResponseEntity<Void> deleteQuery(@PathVariable String username, @PathVariable Long id) {
+    @DeleteMapping("/{username}/{searchedHistoryId}")
+    public ResponseEntity<Void> deleteQuery(@PathVariable String username, @PathVariable Long searchedHistoryId) {
         Long memberId = memberService.getMemberIdByUsername(username);
-        searchService.deleteQuery(memberId, id);
+        searchService.deleteQuery(memberId, searchedHistoryId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/logX/TTT/search/SearchController.java
+++ b/src/main/java/logX/TTT/search/SearchController.java
@@ -33,10 +33,10 @@ public class SearchController {
         return ResponseEntity.ok(recentQueries);
     }
 
-    @DeleteMapping("/{username}/{searchedHistoryId}")
-    public ResponseEntity<Void> deleteQuery(@PathVariable String username, @PathVariable Long searchedHistoryId) {
+    @DeleteMapping("/{username}/{searchHistoryId}")
+    public ResponseEntity<Void> deleteQuery(@PathVariable String username, @PathVariable Long searchHistoryId) {
         Long memberId = memberService.getMemberIdByUsername(username);
-        searchService.deleteQuery(memberId, searchedHistoryId);
+        searchService.deleteQuery(memberId, searchHistoryId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/logX/TTT/search/SearchController.java
+++ b/src/main/java/logX/TTT/search/SearchController.java
@@ -1,6 +1,7 @@
 package logX.TTT.search;
 
 import logX.TTT.member.MemberService;
+import logX.TTT.search.model.SearchDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -26,9 +27,9 @@ public class SearchController {
     }
 
     @GetMapping("/{username}")
-    public ResponseEntity<List<String>> getRecentSearchQueries(@PathVariable String username) {
+    public ResponseEntity<List<SearchDTO>> getRecentSearchQueries(@PathVariable String username) {
         Long memberId = memberService.getMemberIdByUsername(username);
-        List<String> recentQueries = searchService.getRecentSearchQueries(memberId);
+        List<SearchDTO> recentQueries = searchService.getRecentSearchQueries(memberId);
         return ResponseEntity.ok(recentQueries);
     }
 

--- a/src/main/java/logX/TTT/search/SearchRepository.java
+++ b/src/main/java/logX/TTT/search/SearchRepository.java
@@ -1,8 +1,14 @@
 package logX.TTT.search;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface SearchRepository extends JpaRepository<Search, Long> {
     List<Search> findTop10ByMemberIdOrderBySearchedAtDesc(Long memberId);
+
+    void deleteByMemberIdAndId(Long memberId, Long id);
 }

--- a/src/main/java/logX/TTT/search/SearchRepository.java
+++ b/src/main/java/logX/TTT/search/SearchRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface SearchRepository extends JpaRepository<Search, Long> {
     List<Search> findTop10ByMemberIdOrderBySearchedAtDesc(Long memberId);
 
-    void deleteByMemberIdAndId(Long memberId, Long id);
+    void deleteByMemberIdAndSearchedHistoryId(Long memberId, Long searchedHistoryId);
 }

--- a/src/main/java/logX/TTT/search/SearchRepository.java
+++ b/src/main/java/logX/TTT/search/SearchRepository.java
@@ -1,14 +1,11 @@
 package logX.TTT.search;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SearchRepository extends JpaRepository<Search, Long> {
     List<Search> findTop10ByMemberIdOrderBySearchedAtDesc(Long memberId);
 
-    void deleteByMemberIdAndSearchedHistoryId(Long memberId, Long searchedHistoryId);
+    void deleteByMemberIdAndSearchHistoryId(Long memberId, Long searchHistoryId);
 }

--- a/src/main/java/logX/TTT/search/SearchService.java
+++ b/src/main/java/logX/TTT/search/SearchService.java
@@ -34,11 +34,11 @@ public class SearchService {
     public List<SearchDTO> getRecentSearchQueries(Long memberId) {
         List<Search> searchHistories = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
         return searchHistories.stream()
-                .map(search -> new SearchDTO(search.getId(), search.getQuery()))
+                .map(search -> new SearchDTO(search.getSearchedHistoryId(), search.getQuery()))
                 .collect(Collectors.toList());
     }
 
-    public void deleteQuery(Long memberId, Long id) {
-        searchHistoryRepository.deleteByMemberIdAndId(memberId, id);
+    public void deleteQuery(Long memberId, Long searchedHistoryId) {
+        searchHistoryRepository.deleteByMemberIdAndSearchedHistoryId(memberId, searchedHistoryId);
     }
 }

--- a/src/main/java/logX/TTT/search/SearchService.java
+++ b/src/main/java/logX/TTT/search/SearchService.java
@@ -34,11 +34,11 @@ public class SearchService {
     public List<SearchDTO> getRecentSearchQueries(Long memberId) {
         List<Search> searchHistories = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
         return searchHistories.stream()
-                .map(search -> new SearchDTO(search.getSearchedHistoryId(), search.getQuery()))
+                .map(search -> new SearchDTO(search.getSearchHistoryId(), search.getQuery()))
                 .collect(Collectors.toList());
     }
 
     public void deleteQuery(Long memberId, Long searchedHistoryId) {
-        searchHistoryRepository.deleteByMemberIdAndSearchedHistoryId(memberId, searchedHistoryId);
+        searchHistoryRepository.deleteByMemberIdAndSearchHistoryId(memberId, searchedHistoryId);
     }
 }

--- a/src/main/java/logX/TTT/search/SearchService.java
+++ b/src/main/java/logX/TTT/search/SearchService.java
@@ -2,6 +2,7 @@ package logX.TTT.search;
 
 import logX.TTT.member.Member;
 import logX.TTT.member.MemberRepository;
+import logX.TTT.search.model.SearchDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -30,10 +31,10 @@ public class SearchService {
         }
     }
 
-    public List<String> getRecentSearchQueries(Long memberId) {
+    public List<SearchDTO> getRecentSearchQueries(Long memberId) {
         List<Search> searchHistories = searchHistoryRepository.findTop10ByMemberIdOrderBySearchedAtDesc(memberId);
         return searchHistories.stream()
-                .map(Search::getQuery)
+                .map(search -> new SearchDTO(search.getId(), search.getQuery()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/logX/TTT/search/SearchService.java
+++ b/src/main/java/logX/TTT/search/SearchService.java
@@ -37,4 +37,8 @@ public class SearchService {
                 .map(search -> new SearchDTO(search.getId(), search.getQuery()))
                 .collect(Collectors.toList());
     }
+
+    public void deleteQuery(Long memberId, Long id) {
+        searchHistoryRepository.deleteByMemberIdAndId(memberId, id);
+    }
 }

--- a/src/main/java/logX/TTT/search/model/SearchDTO.java
+++ b/src/main/java/logX/TTT/search/model/SearchDTO.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchDTO {
-    private Long searchedHistoryId;
+    private Long searchHistoryId;
     private String query;
 }

--- a/src/main/java/logX/TTT/search/model/SearchDTO.java
+++ b/src/main/java/logX/TTT/search/model/SearchDTO.java
@@ -1,0 +1,13 @@
+package logX.TTT.search.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchDTO {
+    private Long id;
+    private String query;
+}

--- a/src/main/java/logX/TTT/search/model/SearchDTO.java
+++ b/src/main/java/logX/TTT/search/model/SearchDTO.java
@@ -8,6 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SearchDTO {
-    private Long id;
+    private Long searchedHistoryId;
     private String query;
 }


### PR DESCRIPTION
### Feat
- 검색기록 삭제 기능
  - `DELETE` `search/{username}/{searchedHistoryId}`
---
### Fix
- SearchDTO 추가
  - 검색 기록 반환 시
    - 기존 : List<String>
    - 변경 : List<SearchDTO> (String query, Long searchedHistoryId)

- Entity 이름 변경
  - 기존 : id
  - 변경 : searchedHistoryId