### PR TITLE
PostResponse 데이터 추가

### DIFF
--- a/src/main/java/logX/TTT/member/MemberService.java
+++ b/src/main/java/logX/TTT/member/MemberService.java
@@ -69,7 +69,9 @@ public class MemberService {
                 member.getUsername(),
                 member.getIntroduction(),
                 member.getProfileImageUrl(),
-                member.getCreatedAt()
+                member.getCreatedAt(),
+                member.getTotalLikes(),
+                member.getTotalViews()
         );
     }
 
@@ -111,7 +113,9 @@ public class MemberService {
                 member.getUsername(),
                 member.getIntroduction(),
                 member.getProfileImageUrl(),
-                member.getCreatedAt()
+                member.getCreatedAt(),
+                member.getTotalLikes(),
+                member.getTotalViews()
         );
     }
 

--- a/src/main/java/logX/TTT/post/PostRepository.java
+++ b/src/main/java/logX/TTT/post/PostRepository.java
@@ -14,6 +14,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p WHERE p.member.username = :username")
     List<Post> findByUsername(String username);
 
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.member.id = :memberId")
+    int countByMemberId(@Param("memberId") Long memberId);
 
     @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.content LIKE %:keyword%")
     List<Post> findByTitleContainingOrContentDataContaining(@Param("keyword") String keyword);

--- a/src/main/java/logX/TTT/post/PostService.java
+++ b/src/main/java/logX/TTT/post/PostService.java
@@ -103,11 +103,12 @@ public class PostService {
         return new PostResponseDTO(
                 post.getId(),
                 post.getTitle(),
-                post.getContent(), // 'data' 필드에 맞는 데이터 제공
+                post.getMember().getUsername(),
+                post.getContent(),
                 locationDTOs,
-                post.getLikes(),
-                post.getViews(), // Views 리스트
-                post.getViews().size(), // 조회수 개수 반환
+                post.getLikes().size(),
+                post.getViews().size(),
+                post.getViews().size(),
                 post.getCreatedAt()
         );
     }

--- a/src/main/java/logX/TTT/post/PostService.java
+++ b/src/main/java/logX/TTT/post/PostService.java
@@ -88,6 +88,10 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    private int getPostCountByMemberId(Long memberId) {
+        return postRepository.countByMemberId(memberId);
+    }
+
     private void incrementViewCount(Post post) {
         // 조회수 증가 로직 구현
         Views view = new Views(); // Views 객체 생성
@@ -104,11 +108,14 @@ public class PostService {
                 post.getId(),
                 post.getTitle(),
                 post.getMember().getUsername(),
+                post.getMember().getProfileImageUrl(),
+                post.getMember().getIntroduction(),
                 post.getContent(),
                 locationDTOs,
+                getPostCountByMemberId(post.getMember().getId()),
                 post.getLikes().size(),
                 post.getViews().size(),
-                post.getViews().size(),
+                post.getComments().size(),
                 post.getCreatedAt()
         );
     }

--- a/src/main/java/logX/TTT/post/model/PostResponseDTO.java
+++ b/src/main/java/logX/TTT/post/model/PostResponseDTO.java
@@ -19,8 +19,11 @@ public class PostResponseDTO {
     private Long id;
     private String title;
     private String username;
+    private String profileImageUrl;
+    private String introduction;
     private String data;
     private List<LocationDTO> locations;
+    private int postCount;
     private int likeCount;
     private int viewCount;
     private int commentCount;

--- a/src/main/java/logX/TTT/post/model/PostResponseDTO.java
+++ b/src/main/java/logX/TTT/post/model/PostResponseDTO.java
@@ -18,10 +18,11 @@ import java.util.List;
 public class PostResponseDTO {
     private Long id;
     private String title;
+    private String username;
     private String data;
     private List<LocationDTO> locations;
-    private List<Likes> likes;
-    private List<Views> views;
+    private int likeCount;
     private int viewCount;
+    private int commentCount;
     private LocalDateTime createdAt;
 }


### PR DESCRIPTION
### 추가된 데이터
- PostResponseDTO
  - `username` : 사용자 닉네임
  - `profileImageUrl` : 프로필 사진
  - `introduction` : 자기소개
  - `postCount` : 작성한 글 개수
  - `commentCount` : 해당 게시글에 달린 댓글 개수
  - `likeCount` : 좋아요 개수
---
### 수정된 데이터
- `List<Likes> like` -> `likeCount`
- `List<Views> view` -> 삭제
  - 수정한 이유 : 좋아요 리스트를 FE에서 가공하기보다 BE에서 단순 숫자만 반환해주는 것이 효율적임
---
### 추가된 기능
- PostService, PostRepository : 사용자 id를 기반으로 작성한 게시물의 개수를 반환하는 service 및 query 작성

### 코드 추가
- 이전 PR에서 추가된 UserInfoDTO의 데이터 형식에 맞지 않는 service 발견 -> 데이터 추가 완료