### PR TITLE
스크랩 관련 수정

### DIFF
--- a/src/main/java/logX/TTT/config/WebConfig.java
+++ b/src/main/java/logX/TTT/config/WebConfig.java
@@ -1,0 +1,16 @@
+package logX.TTT.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:src/main/resources/static/images/")
+                .setCachePeriod(0); // 캐시 비활성화
+    }
+}

--- a/src/main/java/logX/TTT/post/PostService.java
+++ b/src/main/java/logX/TTT/post/PostService.java
@@ -9,6 +9,7 @@ import logX.TTT.member.MemberRepository;
 import logX.TTT.post.model.PostCreateDTO;
 import logX.TTT.post.model.PostResponseDTO;
 import logX.TTT.post.model.PostSummaryDTO;
+import logX.TTT.scrap.ScrapService;
 import logX.TTT.views.Views;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final LikesService likesService;
+    private final ScrapService scrapService;
     private final HttpSession session;
 
     public PostResponseDTO createPost(PostCreateDTO postCreateDTO) {
@@ -117,12 +119,14 @@ public class PostService {
                 .collect(Collectors.toList());
 
         boolean isLiked = false;
+        boolean isScrapped = false;
 
         // 세션에서 memberId 가져오기
         Long memberId = (Long) session.getAttribute("member");
         System.out.println("memberId = " + memberId);
         if (memberId != null) {
             isLiked = likesService.isPostLikedByUser(post.getId(), memberId);
+            isScrapped = scrapService.isScrappedByUser(post.getId(), memberId);
         }
 
 
@@ -139,7 +143,8 @@ public class PostService {
                 post.getViews().size(),
                 post.getComments().size(),
                 post.getCreatedAt(),
-                isLiked
+                isLiked,
+                isScrapped,
         );
     }
 

--- a/src/main/java/logX/TTT/post/PostService.java
+++ b/src/main/java/logX/TTT/post/PostService.java
@@ -144,7 +144,7 @@ public class PostService {
                 post.getComments().size(),
                 post.getCreatedAt(),
                 isLiked,
-                isScrapped,
+                isScrapped
         );
     }
 

--- a/src/main/java/logX/TTT/post/model/PostResponseDTO.java
+++ b/src/main/java/logX/TTT/post/model/PostResponseDTO.java
@@ -29,4 +29,5 @@ public class PostResponseDTO {
     private int commentCount;
     private LocalDateTime createdAt;
     private boolean liked;
+    private boolean scrapped;
 }

--- a/src/main/java/logX/TTT/scrap/ScrapController.java
+++ b/src/main/java/logX/TTT/scrap/ScrapController.java
@@ -16,9 +16,9 @@ public class ScrapController {
     private final ScrapService scrapService;
 
     // 게시글 스크랩 요청
-    @PostMapping
-    public ResponseEntity<Void> scrapPost(@RequestBody ScrapDTO scrapDTO) {
-        scrapService.scrapPost(scrapDTO);
+    @PostMapping("/{postId}/{memberId}")
+    public ResponseEntity<Void> scrapPost(@PathVariable Long postId, @PathVariable Long memberId) {
+        scrapService.scrapPost(postId, memberId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
@@ -29,9 +29,9 @@ public class ScrapController {
         return ResponseEntity.ok(scraps);
     }
 
-    @DeleteMapping
-    public ResponseEntity<Void> deleteScrap(@RequestBody ScrapDTO scrapDTO) {
-        scrapService.deleteScrap(scrapDTO);
+    @DeleteMapping("/{postId}/{memberId}")
+    public ResponseEntity<Void> deleteScrap(@PathVariable Long postId, @PathVariable Long memberId) {
+        scrapService.deleteScrap(postId, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/logX/TTT/scrap/ScrapRepository.java
+++ b/src/main/java/logX/TTT/scrap/ScrapRepository.java
@@ -10,4 +10,5 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     List<Scrap> findByMember(Member member);
     List<Scrap> findByPost(Post post);
     void deleteByMemberAndPost(Member member, Post post); // 특정 member와 post의 조합으로 삭제
+    boolean existsByPostAndMember(Post post, Member member);
 }

--- a/src/main/java/logX/TTT/scrap/ScrapService.java
+++ b/src/main/java/logX/TTT/scrap/ScrapService.java
@@ -20,10 +20,10 @@ public class ScrapService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
 
-    public void scrapPost(ScrapDTO scrapDTO) {
-        Member member = memberRepository.findById(scrapDTO.getMemberId())
+    public void scrapPost(Long postId, Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("Member not found"));
-        Post post = postRepository.findById(scrapDTO.getPostId())
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("Post not found"));
 
         Scrap scrap = new Scrap();
@@ -43,10 +43,10 @@ public class ScrapService {
     }
 
     @Transactional
-    public void deleteScrap(ScrapDTO scrapDTO) {
-        Member member = memberRepository.findById(scrapDTO.getMemberId())
+    public void deleteScrap(Long postId, Long memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("Member not found"));
-        Post post = postRepository.findById(scrapDTO.getPostId())
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new RuntimeException("Post not found"));
 
         scrapRepository.deleteByMemberAndPost(member, post);

--- a/src/main/java/logX/TTT/scrap/ScrapService.java
+++ b/src/main/java/logX/TTT/scrap/ScrapService.java
@@ -51,4 +51,12 @@ public class ScrapService {
 
         scrapRepository.deleteByMemberAndPost(member, post);
     }
+
+    public boolean isScrappedByUser(Long postId, Long memberId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid post ID"));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid member ID"));
+        return scrapRepository.existsByPostAndMember(post, member);
+    }
 }


### PR DESCRIPTION
- scrapPost (게시글 스크랩 기능) 시 사용자에게 id를 받지 않고 DB에서 자동으로 올라가는 id가 배정됨
  - `@Pathvariable`을 통하여 `postId`, `memberId`를 받은 후에 저장 처리
- 글 반환 시 (`postResponseDTO`) 세션 값 확인 후 로그인 된 유저에 따라 스크랩 여부 (T/F) 반환 