### PR TITLE
관심사 반환 로직 수정, 로그인 반환 코드 수정

### DIFF
--- a/src/main/java/logX/TTT/likes/LikesRepository.java
+++ b/src/main/java/logX/TTT/likes/LikesRepository.java
@@ -3,6 +3,8 @@ package logX.TTT.likes;
 import logX.TTT.member.Member;
 import logX.TTT.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,14 +12,11 @@ import java.util.Optional;
 
 @Repository
 public interface LikesRepository extends JpaRepository<Likes, Long> {
-    // 특정 게시물에 대한 좋아요 목록 조회
     List<Likes> findByPost(Post post);
-
-    // 특정 사용자가 좋아요를 누른 게시물 조회
     List<Likes> findByMember(Member member);
-
     Optional<Likes> findByPostAndMember(Post post, Member member);
     void deleteByPostAndMember(Post post, Member member);
-
     boolean existsByPostAndMember(Post post, Member member);
+    @Query("SELECT l.post FROM Likes l WHERE l.member.id = :memberId")
+    List<Post> findPostsByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/logX/TTT/member/MemberController.java
+++ b/src/main/java/logX/TTT/member/MemberController.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import logX.TTT.comment.CommentService;
 import logX.TTT.likes.LikesService;
+import logX.TTT.member.exception.EmailNotFoundException;
+import logX.TTT.member.exception.InvalidPasswordException;
 import logX.TTT.member.model.*;
 import logX.TTT.post.PostService;
 import logX.TTT.post.model.PostSummaryDTO;
@@ -33,8 +35,12 @@ public class MemberController {
             HttpSession session = request.getSession();
             session.setAttribute("member", loginMember.getId());
             return ResponseEntity.ok().build();
+        } catch (EmailNotFoundException e) {
+            return ResponseEntity.status(404).build();
+        } catch (InvalidPasswordException e) {
+            return ResponseEntity.status(400).build();
         } catch (RuntimeException e) {
-            return ResponseEntity.status(400).body(e.getMessage());
+            return ResponseEntity.status(500).body(e.getMessage());
         }
     }
 

--- a/src/main/java/logX/TTT/member/MemberService.java
+++ b/src/main/java/logX/TTT/member/MemberService.java
@@ -1,6 +1,8 @@
 package logX.TTT.member;
 
 import logX.TTT.likes.LikesRepository;
+import logX.TTT.member.exception.EmailNotFoundException;
+import logX.TTT.member.exception.InvalidPasswordException;
 import logX.TTT.member.model.LoginDTO;
 import logX.TTT.member.model.SignupDTO;
 import logX.TTT.member.model.UpdateMemberDTO;
@@ -24,13 +26,12 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final PostRepository postRepository;
 
-
     public Member login(LoginDTO form) {
         Optional<Member> optionalMember = memberRepository.findByEmail(form.getEmail());
-        Member member = optionalMember.orElseThrow(() -> new RuntimeException("가입된 이메일이 없습니다."));
+        Member member = optionalMember.orElseThrow(() -> new EmailNotFoundException());
 
         if (!passwordEncoder.matches(form.getPassword(), member.getPassword())) { // 비밀번호 대조
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+            throw new InvalidPasswordException();
         }
         return member;
     }

--- a/src/main/java/logX/TTT/member/exception/EmailNotFoundException.java
+++ b/src/main/java/logX/TTT/member/exception/EmailNotFoundException.java
@@ -1,0 +1,7 @@
+package logX.TTT.member.exception;
+
+public class EmailNotFoundException extends RuntimeException {
+    public EmailNotFoundException() {
+        super();
+    }
+}

--- a/src/main/java/logX/TTT/member/exception/InvalidPasswordException.java
+++ b/src/main/java/logX/TTT/member/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package logX.TTT.member.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException() {
+        super();
+    }
+}

--- a/src/main/java/logX/TTT/scrap/ScrapRepository.java
+++ b/src/main/java/logX/TTT/scrap/ScrapRepository.java
@@ -3,6 +3,8 @@ package logX.TTT.scrap;
 import logX.TTT.member.Member;
 import logX.TTT.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +13,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     List<Scrap> findByPost(Post post);
     void deleteByMemberAndPost(Member member, Post post); // 특정 member와 post의 조합으로 삭제
     boolean existsByPostAndMember(Post post, Member member);
+    @Query("SELECT s.post FROM Scrap s WHERE s.member.id = :memberId")
+    List<Post> findPostsByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## Fix

- 관심사 반환 알고리즘 수정
  - 기존
    - _**검색기록**_ 에 관련된 내용 검색
  - 수정
    - _**검색기록**_,  _**좋아요**_, _**스크랩**_ 한 게시물과 관련된 내용 검색
    - 검색된 내용 중 5개의 글들을 랜덤으로 추출
    

- 로그인 반환 코드(status) 수정
  - 기존
    - 성공 (200)
    - 실패 (400, message: 가입된 이메일이 없습니다. | 비밀번호가 일치하지 않습니다)
  - 수정
    - 성공 (200)
    - 이메일 없음 (404)
    - 비밀번호 불일치 (400)
    - 서버 오류 (500)